### PR TITLE
Fix NpmPublishTask workingDir scope

### DIFF
--- a/src/main/kotlin/task/NpmPublishTask.kt
+++ b/src/main/kotlin/task/NpmPublishTask.kt
@@ -75,6 +75,8 @@ open class NpmPublishTask @Inject constructor(
         if (otp != null) "--otp $otp" else null,
         if (dry) "--dry-run" else null
       )
-    )
+    ) {
+      workingDir = packageDir
+    }
   }
 }


### PR DESCRIPTION
## 📖 Description

Fix `NpmPublishTask` workingDir scope. 

## ⚠️ Problem

When using the generated task `publishJsNpmPublicationToNexus` for a custom repository, the publication to Sonatype was reporting a success (HTTP PUT 200) but no artifact was ever uploaded to the expected repository.

Custom Repository config:
```kts
        repository("nexus") {
            access = RESTRICTED
            registry = uri("https://nexus.xxx.ca/repository/npm-internal")
            authToken = [obfuscated]
        }
```

Outputs of the command sent to Node failing to publish was as follow:

```
npm publish /Users/boubalou/dev/xxx/common/build/publications/npm --access restricted --registry https://nexus.xxx.ca/repository/npm-internal/ [authToken obfuscated]
```

When run manually using a terminal while being in `pwd` -> `/Users/boubalou/dev/xxx/common/build/publications/npm`, it was getting published succesfully.
```
npm publish . --access restricted --registry https://nexus.xxx.ca/repository/npm-internal/ [authToken obfuscated]
```

## 🤓 Solution

Turns out that `npm publish` must be executed at the root of the source package to upload flawlessly. It is still unknown to me if this is an issue with Nexus itself, or because we use a custom registry, but it is what it is.

The fix is quite easy, make sure to use the current package directory as the `workingDir` when invoking Node commands for publishing.
