### PR TITLE
Fix license not published

### DIFF
--- a/sandbox/template.package.json
+++ b/sandbox/template.package.json
@@ -1,5 +1,5 @@
 {
-  "licence": "MIT",
+  "license": "MIT",
   "author": {
     "name": "Mr. Should be Overridden"
   }

--- a/src/main/kotlin/dsl/PackageJson.kt
+++ b/src/main/kotlin/dsl/PackageJson.kt
@@ -123,9 +123,9 @@ class PackageJson() : JsonObject<Any>() {
   fun bugs(config: Bugs.() -> Unit = {}) = Bugs(bugs, config).also { bugs = it }
 
   /**
-   * [licence](https://docs.npmjs.com/files/package.json#license)
+   * [license](https://docs.npmjs.com/files/package.json#license)
    */
-  var licence: String? by this
+  var license: String? by this
 
   /**
    * [author](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)


### PR DESCRIPTION
The license doesn't get published because there is a typo in the the `PackageJson` class member, I've corrected it (fixes #18).