### PR TITLE
Fixes #171: exposes the auth, username and password properties of registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,19 @@ kotlin {
 
 npmPublish {
     registries {
+        // For registries expecting an authentiation token, use authToken
         register("npmjs") {
             uri.set("https://registry.npmjs.org")
             authToken.set("obfuscated")
+        }
+        
+        // For registries expecting a username and password, use auth or username + password
+        register("nexus") {
+            uri.set("https://nexus.example.com/repository/npm-internal")
+            username.set("obfuscated")
+            password.set("obfuscated")
+            // Or:
+            // auth.set("base64-encoded-string")
         }
     }
 }

--- a/npm-publish-gradle-plugin/src/main/kotlin/config/registry.kt
+++ b/npm-publish-gradle-plugin/src/main/kotlin/config/registry.kt
@@ -22,6 +22,9 @@ internal fun Project.configure(registry: NpmRegistry) {
   registry.uri.convention(sysProjectEnvPropertyConvention(prefix + "uri").map(::URI))
   registry.otp.convention(sysProjectEnvPropertyConvention(prefix + "otp"))
   registry.authToken.convention(sysProjectEnvPropertyConvention(prefix + "authToken"))
+  registry.auth.convention(sysProjectEnvPropertyConvention(prefix + "auth"))
+  registry.username.convention(sysProjectEnvPropertyConvention(prefix + "username"))
+  registry.password.convention(sysProjectEnvPropertyConvention(prefix + "password"))
   registry.dry.convention(
     sysProjectEnvPropertyConvention(prefix + "dry", extension.dry.map(Boolean?::toString)).map { it.notFalse() }
   )

--- a/npm-publish-gradle-plugin/src/main/kotlin/extension/domain/NpmRegistry.kt
+++ b/npm-publish-gradle-plugin/src/main/kotlin/extension/domain/NpmRegistry.kt
@@ -41,11 +41,36 @@ public abstract class NpmRegistry : NamedInput {
 
   /**
    * Auth token to use when authenticating with the registry.
+   * Either authToken, auth or a username + password should be provided.
    * [More info](https://docs.npmjs.com/about-access-tokens)
    */
   @get:Input
   @get:Optional
   public abstract val authToken: Property<String>
+
+  /**
+   * Base64 authentication string when authenticating with the registry.
+   * Either authToken, auth or a username + password should be provided.
+   */
+  @get:Input
+  @get:Optional
+  public abstract val auth: Property<String>
+
+  /**
+   * Username to use when authenticating with the registry.
+   * Either authToken, auth or a username + password should be provided.
+   */
+  @get:Input
+  @get:Optional
+  public abstract val username: Property<String>
+
+  /**
+   * Password to use when authenticating with the registry.
+   * Either authToken, auth or a username + password should be provided.
+   */
+  @get:Input
+  @get:Optional
+  public abstract val password: Property<String>
 
   /**
    * Specifies if a dry-run should be added to the npm command arguments by default. Dry run does all the

--- a/npm-publish-gradle-plugin/src/main/kotlin/task/NpmPublishTask.kt
+++ b/npm-publish-gradle-plugin/src/main/kotlin/task/NpmPublishTask.kt
@@ -8,7 +8,9 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.plugins.PublishingPlugin.PUBLISH_TASK_GROUP
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.options.Option
+import java.util.*
 
 /**
  * A publishing task that publishes a given package to a given registry.
@@ -74,6 +76,7 @@ public abstract class NpmPublishTask : NpmExecTask() {
     val reg = registry.get()
     val uri = reg.uri.get()
     val repo = "${uri.authority.trim()}${uri.path.trim()}/"
+
     val d = dry.get()
     info {
       "Publishing package at $pDir to ${reg.name} registry ${if (d) "with" else "without"} --dry-run flag"
@@ -85,6 +88,13 @@ public abstract class NpmPublishTask : NpmExecTask() {
       add("--registry=${uri.scheme.trim()}://$repo")
       if (reg.otp.isPresent) add("--otp=${reg.otp.get()}")
       if (reg.authToken.isPresent) add("--//$repo:_authToken=${reg.authToken.get()}")
+      if (reg.auth.isPresent) add("--//$repo:_auth=${reg.auth.get()}")
+      if (reg.username.isPresent) add("--//$repo:username=${reg.username.get()}")
+      if (reg.password.isPresent) {
+        val password = reg.password.get()
+        val encoded = Base64.getEncoder().encodeToString(password.toByteArray(Charsets.UTF_8))
+        add("--//$repo:_password=${encoded}")
+      }
       if (d) add("--dry-run")
       if (tag.isPresent) add("--tag=${tag.get()}")
     }

--- a/npm-publish-gradle-plugin/src/main/kotlin/task/NpmPublishTask.kt
+++ b/npm-publish-gradle-plugin/src/main/kotlin/task/NpmPublishTask.kt
@@ -93,7 +93,7 @@ public abstract class NpmPublishTask : NpmExecTask() {
       if (reg.password.isPresent) {
         val password = reg.password.get()
         val encoded = Base64.getEncoder().encodeToString(password.toByteArray(Charsets.UTF_8))
-        add("--//$repo:_password=${encoded}")
+        add("--//$repo:_password=$encoded")
       }
       if (d) add("--dry-run")
       if (tag.isPresent) add("--tag=${tag.get()}")

--- a/npm-publish-gradle-plugin/src/test/kotlin/extension/domain/NpmRegistryITest.kt
+++ b/npm-publish-gradle-plugin/src/test/kotlin/extension/domain/NpmRegistryITest.kt
@@ -31,6 +31,9 @@ class NpmRegistryITest : ITest() {
     Triple("uri", "https://test.com") { uri.orNull?.toString() },
     Triple("otp", "test") { otp.orNull },
     Triple("authToken", "test") { authToken.orNull },
+    Triple("auth", "test") { auth.orNull },
+    Triple("username", "test") { username.orNull },
+    Triple("password", "test") { password.orNull },
   ).map { (k, v, s) ->
     DynamicTest.dynamicTest("default for NpmRegistry::$k") {
       propertyDefaultTest(k, v, s)


### PR DESCRIPTION
This exposes a couple of extra authentication related properties of npm registry configuration.

I opted not to throw any exceptions if multiple options were found, but instead rely on the behaviour of NPM itself, and to transparently pass the parameters on.

The only field with special changes needed is the `_password` field, which npm expects to have been set as a base64 encoded string in the `.npmrc` file. I've transparently exposed the password field to the plugin's users to simplify usage, but encoded it in the plugin.
I haven't found official documentation about that, but was inspired by this line in the official npm github repository: https://github.com/npm/cli/blob/3b8b11161ee2f88817dcc19b4770040d5bc73261/workspaces/arborist/README.md?plain=1#L42